### PR TITLE
修复三星BUG

### DIFF
--- a/DynamicLoadApk/lib/src/com/ryg/dynamicload/internal/DLProxyImpl.java
+++ b/DynamicLoadApk/lib/src/com/ryg/dynamicload/internal/DLProxyImpl.java
@@ -88,6 +88,12 @@ public class DLProxyImpl {
         Theme superTheme = mProxyActivity.getTheme();
         mTheme = mResources.newTheme();
         mTheme.setTo(superTheme);
+        //Finals适配三星以及部分加载XML出现异常BUG
+        try {
+	     mTheme.applyStyle(mActivityInfo.theme, true);
+	} catch (Exception e) {
+	    e.printStackTrace();
+	}
 
         // TODO: handle mActivityInfo.launchMode here in the future.
     }


### PR DESCRIPTION
三星手机会出现Layout XML错误的异常，大概意思是高度没有定义，其实是主题样式缺少造成的