### PR TITLE
修复activity无主题时打开activity黑屏BUG

### DIFF
--- a/DynamicLoadApk/lib/src/com/ryg/dynamicload/internal/DLProxyImpl.java
+++ b/DynamicLoadApk/lib/src/com/ryg/dynamicload/internal/DLProxyImpl.java
@@ -72,9 +72,21 @@ public class DLProxyImpl {
             if (mClass == null) {
                 mClass = packageInfo.activities[0].name;
             }
+            //Finals 修复主题BUG
+            int defaultTheme = packageInfo.applicationInfo.theme;
             for (ActivityInfo a : packageInfo.activities) {
                 if (a.name.equals(mClass)) {
                     mActivityInfo = a;
+                    //Finals ADD 修复主题没有配置的时候插件异常
+                    if (mActivityInfo.theme == 0 && defaultTheme != 0) {
+		       mActivityInfo.theme = defaultTheme;
+		    } else {
+			if (Build.VERSION.SDK_INT >= 14) {
+			    mActivityInfo.theme = android.R.style.Theme_DeviceDefault;
+			} else {
+			    mActivityInfo.theme = android.R.style.Theme;
+			}
+		    }
                 }
             }
         }


### PR DESCRIPTION
修复安卓XML没有配置主题的时候，无法启动activity的BUG