### PR TITLE
Modified gradle task buildLib to avoid gen huge size jar

### DIFF
--- a/DynamicLoadApk/build.gradle
+++ b/DynamicLoadApk/build.gradle
@@ -14,15 +14,6 @@ buildscript {
 
 def dlPath = '/sdcard/DynamicLoadHost'
 
-def makeJar(String target,String classDir){
-    exec{
-        executable "jar"
-        args "cvf",target
-        args "-C", classDir
-        args "","."
-    }
-}
-
 allprojects {
     repositories {
         jcenter()
@@ -47,14 +38,7 @@ allprojects {
         upload()
     }
 
-    task buildLib(dependsOn:'compileReleaseJava') {
-        def srcDir = project.buildDir.toString() + "/intermediates/classes/release"
-        def destFile = project.buildDir.toString() + File.separator + project.name.toString() + ".jar"
-        println destFile
-//        inputs.dir srcDir
-//        outputs.file destFile
-        doLast {
-            makeJar(destFile, srcDir)
-        }
+    task buildLib (type: Jar, dependsOn:'compileReleaseJava') {
+        from (project.buildDir.toString()+'/intermediates/classes/release')
     }
 }

--- a/DynamicLoadApk/sample/depend_on_interface/doi-plugin/build.gradle
+++ b/DynamicLoadApk/sample/depend_on_interface/doi-plugin/build.gradle
@@ -33,8 +33,8 @@ android {
 }
 
 dependencies {
-    provided files('../../../lib/build/lib.jar')
-    provided files('../doi-common/build/doi-common.jar')
+    provided files('../../../lib/build/libs/lib.jar')
+    provided files('../doi-common/build/libs/doi-common.jar')
     provided files('external-jars/android-support-v4.jar')
 }
 

--- a/DynamicLoadApk/sample/main/main-plugin-a/build.gradle
+++ b/DynamicLoadApk/sample/main/main-plugin-a/build.gradle
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    provided files('../../../lib/build/lib.jar')
+    provided files('../../../lib/build/libs/lib.jar')
     provided files('external-jars/android-support-v4.jar')
 }
 

--- a/DynamicLoadApk/sample/main/main-plugin-b/build.gradle
+++ b/DynamicLoadApk/sample/main/main-plugin-b/build.gradle
@@ -35,7 +35,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     provided project(':lib')
-    provided files('../main-host/build/main-host.jar')
+    provided files('../main-host/build/libs/main-host.jar')
 }
 
 task beforeBuild(dependsOn: ':main-host:buildLib') << {


### PR DESCRIPTION
Gradle Huge Size jar问题
1 使用Gradle内建Jar进行lib生成
2 默认生成目录为build/libs下,修改各个项目引用