### PR TITLE
修改脚本，加入AppcompatActivity的支持

### DIFF
--- a/DynamicLoadApk/lib/build.gradle
+++ b/DynamicLoadApk/lib/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 8

--- a/DynamicLoadApk/lib/build.gradle
+++ b/DynamicLoadApk/lib/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 18
+        targetSdkVersion 23
     }
 
     buildTypes {
@@ -33,5 +33,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile ('com.android.support:support-v4:23.1.1')
+    compile ('com.android.support:appcompat-v7:23.1.1')
 }

--- a/DynamicLoadApk/lib/src/com/ryg/dynamicload/DLBasePluginAppcompatActivity.java
+++ b/DynamicLoadApk/lib/src/com/ryg/dynamicload/DLBasePluginAppcompatActivity.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright (C) 2014 singwhatiwanna(任玉刚) <singwhatiwanna@gmail.com>
+ *
+ * collaborator:田啸,宋思宇,Mr.Simple
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ryg.dynamicload;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.LoaderManager;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup.LayoutParams;
+import android.view.Window;
+import android.view.WindowManager;
+
+import com.ryg.dynamicload.internal.DLIntent;
+import com.ryg.dynamicload.internal.DLPluginManager;
+import com.ryg.dynamicload.internal.DLPluginPackage;
+import com.ryg.utils.DLConstants;
+
+public class DLBasePluginAppcompatActivity extends AppCompatActivity implements DLPlugin {
+
+    private static final String TAG = "DLBasePluginFragmentActivity";
+
+    /**
+     * 代理FragmentActivity，可以当作Context来使用，会根据需要来决定是否指向this
+     */
+    protected FragmentActivity mProxyActivity;
+
+    /**
+     * 等同于mProxyActivity，可以当作Context来使用，会根据需要来决定是否指向this<br/>
+     * 可以当作this来使用
+     */
+    protected FragmentActivity that;
+    protected int mFrom = DLConstants.FROM_INTERNAL;
+    protected DLPluginManager mPluginManager;
+    protected DLPluginPackage mPluginPackage;
+
+    @Override
+    public void attach(Activity proxyActivity, DLPluginPackage pluginPackage) {
+        Log.d(TAG, "attach: proxyActivity= " + proxyActivity);
+        mProxyActivity = (FragmentActivity) proxyActivity;
+        that = mProxyActivity;
+        mPluginPackage = pluginPackage;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+            mFrom = savedInstanceState.getInt(DLConstants.FROM, DLConstants.FROM_INTERNAL);
+        }
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onCreate(savedInstanceState);
+            mProxyActivity = this;
+            that = mProxyActivity;
+        }
+
+        mPluginManager = DLPluginManager.getInstance(that);
+        Log.d(TAG, "onCreate: from= "
+                + (mFrom == DLConstants.FROM_INTERNAL ? "DLConstants.FROM_INTERNAL" : "FROM_EXTERNAL"));
+    }
+
+    @Override
+    public void setContentView(View view) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.setContentView(view);
+        } else {
+            mProxyActivity.setContentView(view);
+        }
+    }
+
+    @Override
+    public void setContentView(View view, LayoutParams params) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.setContentView(view, params);
+        } else {
+            mProxyActivity.setContentView(view, params);
+        }
+    }
+
+    @Override
+    public void setContentView(int layoutResID) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.setContentView(layoutResID);
+        } else {
+            mProxyActivity.setContentView(layoutResID);
+        }
+    }
+
+    @Override
+    public void addContentView(View view, LayoutParams params) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.addContentView(view, params);
+        } else {
+            mProxyActivity.addContentView(view, params);
+        }
+    }
+
+    @Override
+    public View findViewById(int id) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.findViewById(id);
+        } else {
+            return mProxyActivity.findViewById(id);
+        }
+    }
+
+    @Override
+    public Intent getIntent() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getIntent();
+        } else {
+            return mProxyActivity.getIntent();
+        }
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getClassLoader();
+        } else {
+            return mProxyActivity.getClassLoader();
+        }
+    }
+
+    @Override
+    public Resources getResources() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getResources();
+        } else {
+            return mProxyActivity.getResources();
+        }
+    }
+
+    @Override
+    public String getPackageName() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getPackageName();
+        } else {
+            return mPluginPackage.packageName;
+        }
+    }
+
+    @Override
+    public LayoutInflater getLayoutInflater() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getLayoutInflater();
+        } else {
+            return mProxyActivity.getLayoutInflater();
+        }
+    }
+
+    @Override
+    public MenuInflater getMenuInflater() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getMenuInflater();
+        } else {
+            return mProxyActivity.getMenuInflater();
+        }
+    }
+
+    @Override
+    public SharedPreferences getSharedPreferences(String name, int mode) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getSharedPreferences(name, mode);
+        } else {
+            return mProxyActivity.getSharedPreferences(name, mode);
+        }
+    }
+
+    @Override
+    public Context getApplicationContext() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getApplicationContext();
+        } else {
+            return mProxyActivity.getApplicationContext();
+        }
+    }
+
+    @Override
+    public WindowManager getWindowManager() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getWindowManager();
+        } else {
+            return mProxyActivity.getWindowManager();
+        }
+    }
+
+    @Override
+    public Window getWindow() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getWindow();
+        } else {
+            return mProxyActivity.getWindow();
+        }
+    }
+
+    @Override
+    public Object getSystemService(String name) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getSystemService(name);
+        } else {
+            return mProxyActivity.getSystemService(name);
+        }
+    }
+
+    @Override
+    public void finish() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.finish();
+        } else {
+            mProxyActivity.finish();
+        }
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onActivityResult(requestCode, resultCode, data);
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onBackPressed();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onStart();
+        }
+    }
+
+    @Override
+    public void onRestart() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onRestart();
+        }
+    }
+
+    @Override
+    public void onRestoreInstanceState(Bundle savedInstanceState) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onRestoreInstanceState(savedInstanceState);
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onSaveInstanceState(outState);
+        }
+    }
+
+    public void onNewIntent(Intent intent) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onNewIntent(intent);
+        }
+    }
+
+    @Override
+    public void onResume() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onResume();
+        }
+    }
+
+    @Override
+    public void onPause() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onPause();
+        }
+    }
+
+    @Override
+    public void onStop() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onDestroy();
+        }
+    }
+
+    public boolean onTouchEvent(MotionEvent event) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.onTouchEvent(event);
+        }
+        return false;
+    }
+
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.onKeyUp(keyCode, event);
+        }
+        return false;
+    }
+
+    public void onWindowAttributesChanged(WindowManager.LayoutParams params) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onWindowAttributesChanged(params);
+        }
+    }
+
+    public void onWindowFocusChanged(boolean hasFocus) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            super.onWindowFocusChanged(hasFocus);
+        }
+    }
+
+    public boolean onCreateOptionsMenu(Menu menu) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.onCreateOptionsMenu(menu);
+        }
+        return true;
+    }
+
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return onOptionsItemSelected(item);
+        }
+        return false;
+    }
+
+    /**
+     * @param dlIntent
+     * @return may be {@link #START_RESULT_SUCCESS}, {@link #START_RESULT_NO_PKG},
+     *         {@link #START_RESULT_NO_CLASS}, {@link #START_RESULT_TYPE_ERROR}
+     */
+    public int startPluginActivity(DLIntent dlIntent) {
+        return startPluginActivityForResult(dlIntent, -1);
+    }
+
+    /**
+     * @param dlIntent
+     * @return may be {@link #START_RESULT_SUCCESS}, {@link #START_RESULT_NO_PKG},
+     *         {@link #START_RESULT_NO_CLASS}, {@link #START_RESULT_TYPE_ERROR}
+     */
+    public int startPluginActivityForResult(DLIntent dlIntent, int requestCode) {
+        if (mFrom == DLConstants.FROM_EXTERNAL) {
+            if (dlIntent.getPluginPackage() == null) {
+                dlIntent.setPluginPackage(mPluginPackage.packageName);
+            }
+        }
+        return mPluginManager.startPluginActivityForResult(that, dlIntent, requestCode);
+    }
+    
+    public int startPluginService(DLIntent dlIntent) {
+        if (mFrom == DLConstants.FROM_EXTERNAL) {
+            if (dlIntent.getPluginPackage() == null) {
+                dlIntent.setPluginPackage(mPluginPackage.packageName);
+            }
+        }
+        return mPluginManager.startPluginService(that, dlIntent);
+    }
+    
+    public int stopPluginService(DLIntent dlIntent) {
+        if (mFrom == DLConstants.FROM_EXTERNAL) {
+            if (dlIntent.getPluginPackage() == null) {
+                dlIntent.setPluginPackage(mPluginPackage.packageName);
+            }
+        }
+        return mPluginManager.stopPluginService(that, dlIntent);
+    }
+    
+    public int bindPluginService(DLIntent dlIntent, ServiceConnection conn, int flags) {
+        if (mFrom == DLConstants.FROM_EXTERNAL) {
+            if (dlIntent.getPluginPackage() == null) {
+                dlIntent.setPluginPackage(mPluginPackage.packageName);
+            }
+        }
+        return mPluginManager.bindPluginService(that, dlIntent, conn, flags);
+    }
+    
+    public int unBindPluginService(DLIntent dlIntent, ServiceConnection conn) {
+        if (mFrom == DLConstants.FROM_EXTERNAL) {
+            if (dlIntent.getPluginPackage() == null)
+            dlIntent.setPluginPackage(mPluginPackage.packageName);
+        }
+        return mPluginManager.unBindPluginService(that, dlIntent, conn);
+    }
+
+    // ------------------------------------------------------------------------
+    // methods override from FragmentActivity
+    // ------------------------------------------------------------------------
+
+    @Override
+    public FragmentManager getSupportFragmentManager() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getSupportFragmentManager();
+        }
+        return mProxyActivity.getSupportFragmentManager();
+    }
+
+    @Override
+    public LoaderManager getSupportLoaderManager() {
+        if (mFrom == DLConstants.FROM_INTERNAL) {
+            return super.getSupportLoaderManager();
+        }
+        return mProxyActivity.getSupportLoaderManager();
+    }
+
+}

--- a/DynamicLoadApk/lib/src/com/ryg/dynamicload/DLBasePluginAppcompatActivity.java
+++ b/DynamicLoadApk/lib/src/com/ryg/dynamicload/DLBasePluginAppcompatActivity.java
@@ -52,13 +52,13 @@ public class DLBasePluginAppcompatActivity extends AppCompatActivity implements 
     /**
      * 代理FragmentActivity，可以当作Context来使用，会根据需要来决定是否指向this
      */
-    protected FragmentActivity mProxyActivity;
+    protected AppCompatActivity mProxyActivity;
 
     /**
      * 等同于mProxyActivity，可以当作Context来使用，会根据需要来决定是否指向this<br/>
      * 可以当作this来使用
      */
-    protected FragmentActivity that;
+    protected AppCompatActivity that;
     protected int mFrom = DLConstants.FROM_INTERNAL;
     protected DLPluginManager mPluginManager;
     protected DLPluginPackage mPluginPackage;
@@ -66,7 +66,7 @@ public class DLBasePluginAppcompatActivity extends AppCompatActivity implements 
     @Override
     public void attach(Activity proxyActivity, DLPluginPackage pluginPackage) {
         Log.d(TAG, "attach: proxyActivity= " + proxyActivity);
-        mProxyActivity = (FragmentActivity) proxyActivity;
+        mProxyActivity = (AppCompatActivity) proxyActivity;
         that = mProxyActivity;
         mPluginPackage = pluginPackage;
     }

--- a/DynamicLoadApk/lib/src/com/ryg/dynamicload/DLProxyAppcompatActivity.java
+++ b/DynamicLoadApk/lib/src/com/ryg/dynamicload/DLProxyAppcompatActivity.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2014 singwhatiwanna(任玉刚) <singwhatiwanna@gmail.com>
+ *
+ * collaborator:田啸,宋思宇,Mr.Simple
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ryg.dynamicload;
+
+import android.content.Intent;
+import android.content.res.AssetManager;
+import android.content.res.Resources;
+import android.content.res.Resources.Theme;
+import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
+import android.support.v7.app.AppCompatActivity;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.WindowManager.LayoutParams;
+
+import com.ryg.dynamicload.internal.DLAttachable;
+import com.ryg.dynamicload.internal.DLPluginManager;
+import com.ryg.dynamicload.internal.DLProxyImpl;
+
+public class DLProxyAppcompatActivity extends AppCompatActivity implements DLAttachable {
+
+    protected DLPlugin mRemoteActivity;
+    private DLProxyImpl impl = new DLProxyImpl(this);
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        impl.onCreate(getIntent());
+    }
+
+    @Override
+    public void attach(DLPlugin remoteActivity, DLPluginManager pluginManager) {
+        mRemoteActivity = remoteActivity;
+    }
+
+    @Override
+    public AssetManager getAssets() {
+        return impl.getAssets() == null ? super.getAssets() : impl.getAssets();
+    }
+
+    @Override
+    public Resources getResources() {
+        return impl.getResources() == null ? super.getResources() : impl.getResources();
+    }
+
+    @Override
+    public Theme getTheme() {
+        return impl.getTheme() == null ? super.getTheme() : impl.getTheme();
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return impl.getClassLoader();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        mRemoteActivity.onActivityResult(requestCode, resultCode, data);
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    protected void onStart() {
+        mRemoteActivity.onStart();
+        super.onStart();
+    }
+
+    @Override
+    protected void onRestart() {
+        mRemoteActivity.onRestart();
+        super.onRestart();
+    }
+
+    @Override
+    protected void onResume() {
+        mRemoteActivity.onResume();
+        super.onResume();
+    }
+
+    @Override
+    protected void onPause() {
+        mRemoteActivity.onPause();
+        super.onPause();
+    }
+
+    @Override
+    protected void onStop() {
+        mRemoteActivity.onStop();
+        super.onStop();
+    }
+
+    @Override
+    protected void onDestroy() {
+        mRemoteActivity.onDestroy();
+        super.onDestroy();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        mRemoteActivity.onSaveInstanceState(outState);
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        mRemoteActivity.onRestoreInstanceState(savedInstanceState);
+        super.onRestoreInstanceState(savedInstanceState);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        mRemoteActivity.onNewIntent(intent);
+        super.onNewIntent(intent);
+    }
+
+    @Override
+    public void onBackPressed() {
+        mRemoteActivity.onBackPressed();
+        super.onBackPressed();
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        super.onTouchEvent(event);
+        return mRemoteActivity.onTouchEvent(event);
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        super.onKeyUp(keyCode, event);
+        return mRemoteActivity.onKeyUp(keyCode, event);
+    }
+
+    @Override
+    public void onWindowAttributesChanged(LayoutParams params) {
+        mRemoteActivity.onWindowAttributesChanged(params);
+        super.onWindowAttributesChanged(params);
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        mRemoteActivity.onWindowFocusChanged(hasFocus);
+        super.onWindowFocusChanged(hasFocus);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        mRemoteActivity.onCreateOptionsMenu(menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        mRemoteActivity.onOptionsItemSelected(item);
+        return super.onOptionsItemSelected(item);
+    }
+
+}

--- a/DynamicLoadApk/lib/src/com/ryg/dynamicload/DLProxyAppcompatActivity.java
+++ b/DynamicLoadApk/lib/src/com/ryg/dynamicload/DLProxyAppcompatActivity.java
@@ -151,7 +151,9 @@ public class DLProxyAppcompatActivity extends AppCompatActivity implements DLAtt
 
     @Override
     public void onWindowAttributesChanged(LayoutParams params) {
-        mRemoteActivity.onWindowAttributesChanged(params);
+        if (mRemoteActivity!=null) {
+            mRemoteActivity.onWindowAttributesChanged(params);
+        }
         super.onWindowAttributesChanged(params);
     }
 

--- a/DynamicLoadApk/lib/src/com/ryg/dynamicload/internal/DLPluginManager.java
+++ b/DynamicLoadApk/lib/src/com/ryg/dynamicload/internal/DLPluginManager.java
@@ -104,7 +104,7 @@ public class DLPluginManager {
     /**
      * Load a apk. Before start a plugin Activity, we should do this first.<br/>
      * NOTE : will only be called by host apk.
-     * 
+     *
      * @param dexPath
      */
     public DLPluginPackage loadApk(String dexPath) {
@@ -114,10 +114,8 @@ public class DLPluginManager {
     }
 
     /**
-     * @param dexPath
-     *            plugin path
-     * @param hasSoLib
-     *            whether exist so lib in plugin
+     * @param dexPath  plugin path
+     * @param hasSoLib whether exist so lib in plugin
      * @return
      */
     public DLPluginPackage loadApk(final String dexPath, boolean hasSoLib) {
@@ -139,7 +137,7 @@ public class DLPluginManager {
 
     /**
      * prepare plugin runtime env, has DexClassLoader, Resources, and so on.
-     * 
+     *
      * @param packageInfo
      * @param dexPath
      * @return
@@ -193,7 +191,7 @@ public class DLPluginManager {
 
     /**
      * copy .so file to pluginlib dir.
-     * 
+     *
      * @param dexPath
      * @param hasSoLib
      */
@@ -221,8 +219,8 @@ public class DLPluginManager {
      * @param dlIntent
      * @param requestCode
      * @return One of below: {@link #START_RESULT_SUCCESS}
-     *         {@link #START_RESULT_NO_PKG} {@link #START_RESULT_NO_CLASS}
-     *         {@link #START_RESULT_TYPE_ERROR}
+     * {@link #START_RESULT_NO_PKG} {@link #START_RESULT_NO_CLASS}
+     * {@link #START_RESULT_TYPE_ERROR}
      */
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
     public int startPluginActivityForResult(Context context, DLIntent dlIntent, int requestCode) {
@@ -242,6 +240,7 @@ public class DLPluginManager {
             return START_RESULT_NO_PKG;
         }
 
+        //这里是要启动Activity的完整类名,后面的操作会被反射构造一个实例
         final String className = getPluginActivityFullPath(dlIntent, pluginPackage);
         Class<?> clazz = loadPluginClass(pluginPackage.classLoader, className);
         if (clazz == null) {
@@ -250,6 +249,7 @@ public class DLPluginManager {
 
         // get the proxy activity class, the proxy activity will launch the
         // plugin activity.
+        //这里是代理Activity的类名，从这里可以看出，每次启动的都是代理Activity
         Class<? extends Activity> activityClass = getProxyActivityClass(clazz);
         if (activityClass == null) {
             return START_RESULT_TYPE_ERROR;
@@ -282,17 +282,17 @@ public class DLPluginManager {
                 mResult = result;
             }
         });
-        
+
         return mResult;
     }
-    
+
     public int stopPluginService(final Context context, final DLIntent dlIntent) {
         if (mFrom == DLConstants.FROM_INTERNAL) {
             dlIntent.setClassName(context, dlIntent.getPluginClass());
             context.stopService(dlIntent);
             return DLPluginManager.START_RESULT_SUCCESS;
         }
-        
+
         fetchProxyServiceClass(dlIntent, new OnFetchProxyServiceClass() {
             @Override
             public void onFetch(int result, Class<? extends Service> proxyServiceClass) {
@@ -305,12 +305,12 @@ public class DLPluginManager {
                 mResult = result;
             }
         });
-        
+
         return mResult;
     }
 
     public int bindPluginService(final Context context, final DLIntent dlIntent, final ServiceConnection conn,
-            final int flags) {
+                                 final int flags) {
         if (mFrom == DLConstants.FROM_INTERNAL) {
             dlIntent.setClassName(context, dlIntent.getPluginClass());
             context.bindService(dlIntent, conn, flags);
@@ -322,7 +322,7 @@ public class DLPluginManager {
             public void onFetch(int result, Class<? extends Service> proxyServiceClass) {
                 // TODO Auto-generated method stub
                 if (result == START_RESULT_SUCCESS) {
-			        dlIntent.setClass(context, proxyServiceClass);
+                    dlIntent.setClass(context, proxyServiceClass);
                     // Bind代理Service
                     context.bindService(dlIntent, conn, flags);
                 }
@@ -356,6 +356,7 @@ public class DLPluginManager {
 
     /**
      * 获取代理ServiceClass
+     *
      * @param dlIntent
      * @param fetchProxyServiceClass
      */
@@ -414,9 +415,8 @@ public class DLPluginManager {
     /**
      * get the proxy activity class, the proxy activity will delegate the plugin
      * activity
-     * 
-     * @param clazz
-     *            target activity's class
+     *
+     * @param clazz target activity's class
      * @return
      */
     private Class<? extends Activity> getProxyActivityClass(Class<?> clazz) {

--- a/DynamicLoadApk/lib/src/com/ryg/dynamicload/internal/DLPluginManager.java
+++ b/DynamicLoadApk/lib/src/com/ryg/dynamicload/internal/DLPluginManager.java
@@ -36,9 +36,11 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.ryg.dynamicload.DLBasePluginActivity;
+import com.ryg.dynamicload.DLBasePluginAppcompatActivity;
 import com.ryg.dynamicload.DLBasePluginFragmentActivity;
 import com.ryg.dynamicload.DLBasePluginService;
 import com.ryg.dynamicload.DLProxyActivity;
+import com.ryg.dynamicload.DLProxyAppcompatActivity;
 import com.ryg.dynamicload.DLProxyFragmentActivity;
 import com.ryg.dynamicload.DLProxyService;
 import com.ryg.utils.DLConstants;
@@ -425,6 +427,8 @@ public class DLPluginManager {
             activityClass = DLProxyActivity.class;
         } else if (DLBasePluginFragmentActivity.class.isAssignableFrom(clazz)) {
             activityClass = DLProxyFragmentActivity.class;
+        } else if (DLBasePluginAppcompatActivity.class.isAssignableFrom(clazz)){
+            activityClass = DLProxyAppcompatActivity.class;
         }
 
         return activityClass;

--- a/DynamicLoadApk/local.properties
+++ b/DynamicLoadApk/local.properties
@@ -7,5 +7,5 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Thu Feb 05 16:29:55 CST 2015
-sdk.dir=D\:\\adt-bundle-windows-x86_64-20130219\\sdk
+#Fri Oct 21 09:22:25 CST 2016
+sdk.dir=D\:\\Android\\sdk_as

--- a/DynamicLoadApk/sample/depend_on_interface/doi-common/build.gradle
+++ b/DynamicLoadApk/sample/depend_on_interface/doi-common/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 23
     buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 18
+        targetSdkVersion 23
     }
 
     buildTypes {

--- a/DynamicLoadApk/sample/depend_on_interface/doi-host/build.gradle
+++ b/DynamicLoadApk/sample/depend_on_interface/doi-host/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 23
     buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
+        targetSdkVersion 23
     }
 
     buildTypes {

--- a/DynamicLoadApk/sample/depend_on_interface/doi-host/src/com/ryg/dynamicload/sample/doihost/MainActivity.java
+++ b/DynamicLoadApk/sample/depend_on_interface/doi-host/src/com/ryg/dynamicload/sample/doihost/MainActivity.java
@@ -67,6 +67,7 @@ public class MainActivity extends Activity implements OnItemClickListener {
             item.pluginPath = plugin.getAbsolutePath();
             item.packageInfo = DLUtils.getPackageInfo(this, item.pluginPath);
             mPluginItems.add(item);
+//            这里做的工作就包括把sd卡中的apk的资源加载到项目中来
             DLPluginManager.getInstance(this).loadApk(item.pluginPath);
         }
 

--- a/DynamicLoadApk/sample/depend_on_interface/doi-plugin/build.gradle
+++ b/DynamicLoadApk/sample/depend_on_interface/doi-plugin/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 23
     buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
+        targetSdkVersion 23
     }
 
     buildTypes {
@@ -33,9 +33,9 @@ android {
 }
 
 dependencies {
-    provided files('../../../lib/build/libs/lib.jar')
-    provided files('../doi-common/build/libs/doi-common.jar')
-    provided files('external-jars/android-support-v4.jar')
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile project(':lib')
+    compile project(':doi-common')
 }
 
 task beforeBuild(dependsOn: [':doi-common:buildLib', ':lib:buildLib']) {

--- a/DynamicLoadApk/sample/main/main-host/AndroidManifest.xml
+++ b/DynamicLoadApk/sample/main/main-host/AndroidManifest.xml
@@ -69,6 +69,18 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.ryg.dynamicload.DLProxyAppcompatActivity"
+            android:label="@string/app_name"
+            android:theme="@style/DLAppCompat">
+            <!--<intent-filter>-->
+                <!--<action android:name="com.ryg.dynamicload.proxy.fragmentactivity.VIEW" />-->
+
+                <!--<category android:name="android.intent.category.DEFAULT" />-->
+            <!--</intent-filter>-->
+        </activity>
+
         <service android:name="com.ryg.dynamicload.DLProxyService" >
 
             <!--

--- a/DynamicLoadApk/sample/main/main-host/AndroidManifest.xml
+++ b/DynamicLoadApk/sample/main/main-host/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
 
     <application
+        android:name=".HostApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name" >

--- a/DynamicLoadApk/sample/main/main-host/build.gradle
+++ b/DynamicLoadApk/sample/main/main-host/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 8

--- a/DynamicLoadApk/sample/main/main-host/build.gradle
+++ b/DynamicLoadApk/sample/main/main-host/build.gradle
@@ -1,15 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
+        targetSdkVersion 23
+        multiDexEnabled true
     }
 
     buildTypes {
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
@@ -33,8 +35,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.android.support:multidex:1.0.1'
     compile project(':lib')
+    compile ('com.android.support:support-v4:23.1.1')
 }
 
 //def makeJar(String target,String classDir){

--- a/DynamicLoadApk/sample/main/main-host/res/values/styles.xml
+++ b/DynamicLoadApk/sample/main/main-host/res/values/styles.xml
@@ -17,4 +17,9 @@
         <!-- All customizations that are NOT specific to a particular API-level can go here. -->
     </style>
 
+
+    <style name="DLAppCompat" parent="Theme.AppCompat.Light.DarkActionBar">
+        <!--在Android 4.4之前的版本上运行，直接跟随系统主题-->
+    </style>
+
 </resources>

--- a/DynamicLoadApk/sample/main/main-host/src/com/ryg/dynamicload/sample/mainhost/HostApplication.java
+++ b/DynamicLoadApk/sample/main/main-host/src/com/ryg/dynamicload/sample/mainhost/HostApplication.java
@@ -1,0 +1,17 @@
+package com.ryg.dynamicload.sample.mainhost;
+
+import android.app.Application;
+import android.support.multidex.MultiDex;
+
+/**
+ * Created by 王韬 on 2016/10/21.
+ */
+
+public class HostApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        MultiDex.install(this);
+    }
+}

--- a/DynamicLoadApk/sample/main/main-plugin-a/build.gradle
+++ b/DynamicLoadApk/sample/main/main-plugin-a/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 23
     buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
+        targetSdkVersion 23
     }
 
     buildTypes {
@@ -33,8 +33,8 @@ android {
 }
 
 dependencies {
-    provided files('../../../lib/build/libs/lib.jar')
-    provided files('external-jars/android-support-v4.jar')
+    compile project(':lib')
+    compile ('com.android.support:support-v4:23.1.1')
 }
 
 task beforeBuild(dependsOn: ':lib:buildLib') << {

--- a/DynamicLoadApk/sample/main/main-plugin-a/build.gradle
+++ b/DynamicLoadApk/sample/main/main-plugin-a/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "19.1.0"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 8
@@ -33,8 +33,10 @@ android {
 }
 
 dependencies {
-    compile project(':lib')
-    compile ('com.android.support:support-v4:23.1.1')
+//    这边不知道为什么，如果compile project(':lib')的话，单独运行正常，但是作为动态加载，放到sd卡中的时候，就不正常了
+    provided files('../../../lib/build/libs/lib.jar')
+    compile('com.android.support:support-v4:23.1.1')
+    compile ('com.android.support:appcompat-v7:23.1.1')
 }
 
 task beforeBuild(dependsOn: ':lib:buildLib') << {

--- a/DynamicLoadApk/sample/main/main-plugin-a/res/layout/test.xml
+++ b/DynamicLoadApk/sample/main/main-plugin-a/res/layout/test.xml
@@ -4,6 +4,13 @@
     android:layout_height="match_parent"
     android:orientation="vertical" >
 
+    <android.support.v7.widget.Toolbar
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:background="@android:color/holo_red_dark">
+
+    </android.support.v7.widget.Toolbar>
+
     <EditText
         android:id="@+id/editText1"
         android:layout_width="match_parent"

--- a/DynamicLoadApk/sample/main/main-plugin-a/src/com/ryg/dynamicload/sample/mainplugin/MainActivity.java
+++ b/DynamicLoadApk/sample/main/main-plugin-a/src/com/ryg/dynamicload/sample/mainplugin/MainActivity.java
@@ -26,7 +26,7 @@ public class MainActivity extends DLBasePluginActivity {
 
     private static final String TAG = "Client-MainActivity";
     private ServiceConnection mConnecton;
-    
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -48,6 +48,7 @@ public class MainActivity extends DLBasePluginActivity {
         button.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
+//                主要是第二个参数，指定要启动的页面，因为Activity没有注册，走的也是主Activity启动apk里面Activity的流程，实际启动的是代理Activity
                 DLIntent intent = new DLIntent(getPackageName(), TestFragmentActivity.class);
                 // 传递Parcelable类型的数据
                 intent.putExtra("person", new Person("plugin-a", 22));
@@ -55,7 +56,7 @@ public class MainActivity extends DLBasePluginActivity {
                 startPluginActivityForResult(intent, 0);
             }
         });
-        
+
         Button button2 = new Button(context);
         button2.setText("Start Service");
         layout.addView(button2, LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
@@ -65,8 +66,8 @@ public class MainActivity extends DLBasePluginActivity {
                 startPluginService(intent);
             }
         });
-        
-       
+
+
         Button button3 = new Button(context);
         button3.setText("bind Service");
         layout.addView(button3, LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
@@ -77,8 +78,9 @@ public class MainActivity extends DLBasePluginActivity {
                     mConnecton = new ServiceConnection() {
                         public void onServiceDisconnected(ComponentName name) {
                         }
+
                         public void onServiceConnected(ComponentName name, IBinder binder) {
-                            int sum = ((ITestServiceInterface)binder).sum(5, 5);
+                            int sum = ((ITestServiceInterface) binder).sum(5, 5);
                             Log.e("MainActivity", "onServiceConnected sum(5 + 5) = " + sum);
                         }
                     };
@@ -87,7 +89,7 @@ public class MainActivity extends DLBasePluginActivity {
                 bindPluginService(intent, mConnecton, Context.BIND_AUTO_CREATE);
             }
         });
-        
+
         Button button4 = new Button(context);
         button4.setText("unbind Service");
         layout.addView(button4, LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);

--- a/DynamicLoadApk/sample/main/main-plugin-a/src/com/ryg/dynamicload/sample/mainplugin/TestFragmentActivity.java
+++ b/DynamicLoadApk/sample/main/main-plugin-a/src/com/ryg/dynamicload/sample/mainplugin/TestFragmentActivity.java
@@ -18,7 +18,7 @@ import com.ryg.dynamicload.internal.DLIntent;
 import com.ryg.dynamicload.internal.DLPluginManager;
 import com.ryg.dynamicload.sample.mainplugina.R;
 
-public class TestFragmentActivity extends DLBasePluginAppcompatActivity
+public class TestFragmentActivity extends DLBasePluginFragmentActivity
         implements OnClickListener {
 
     private static final String TAG = "TestFragmentActivity";

--- a/DynamicLoadApk/sample/main/main-plugin-a/src/com/ryg/dynamicload/sample/mainplugin/TestFragmentActivity.java
+++ b/DynamicLoadApk/sample/main/main-plugin-a/src/com/ryg/dynamicload/sample/mainplugin/TestFragmentActivity.java
@@ -18,6 +18,8 @@ import com.ryg.dynamicload.internal.DLIntent;
 import com.ryg.dynamicload.internal.DLPluginManager;
 import com.ryg.dynamicload.sample.mainplugina.R;
 
+import static android.app.Activity.RESULT_FIRST_USER;
+
 public class TestFragmentActivity extends DLBasePluginFragmentActivity
         implements OnClickListener {
 

--- a/DynamicLoadApk/sample/main/main-plugin-a/src/com/ryg/dynamicload/sample/mainplugin/TestFragmentActivity.java
+++ b/DynamicLoadApk/sample/main/main-plugin-a/src/com/ryg/dynamicload/sample/mainplugin/TestFragmentActivity.java
@@ -12,12 +12,13 @@ import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.Toast;
 
+import com.ryg.dynamicload.DLBasePluginAppcompatActivity;
 import com.ryg.dynamicload.DLBasePluginFragmentActivity;
 import com.ryg.dynamicload.internal.DLIntent;
 import com.ryg.dynamicload.internal.DLPluginManager;
 import com.ryg.dynamicload.sample.mainplugina.R;
 
-public class TestFragmentActivity extends DLBasePluginFragmentActivity
+public class TestFragmentActivity extends DLBasePluginAppcompatActivity
         implements OnClickListener {
 
     private static final String TAG = "TestFragmentActivity";

--- a/DynamicLoadApk/sample/main/main-plugin-b/build.gradle
+++ b/DynamicLoadApk/sample/main/main-plugin-b/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 23
     buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
+        targetSdkVersion 23
     }
 
     buildTypes {
@@ -33,9 +33,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    provided project(':lib')
-    provided files('../main-host/build/libs/main-host.jar')
+    compile project(':lib')
+    compile files('../main-host/build/libs/main-host.jar')
 }
 
 task beforeBuild(dependsOn: ':main-host:buildLib') << {


### PR DESCRIPTION
不依赖本地libs中的库，都依赖jcenter上的，这样好管理，也不用compile和provided结合来避免冲突。compilesdk改成23的（更符合现在的开发），lib中加入了AppcompatActivity的代理类和基类，但是暂时有问题，代理AppcompatActivity类启动就报错，希望大伙多多完善和解决